### PR TITLE
More compact code

### DIFF
--- a/contain-cover.js
+++ b/contain-cover.js
@@ -1,4 +1,4 @@
-function fit(contains = true){
+function fit(contains){
     return function(containerWidth, containerHeight, width, height){
         let doRatio = width / height;
         let cRatio = containerWidth / containerHeight;
@@ -23,10 +23,6 @@ function fit(contains = true){
     }
 }
 
-export let contain = fit(true);
-export let cover = fit(false);
-
-export default {
-    contain : contain,
-    cover : cover
-};
+export const contain = fit(true);
+export const cover = fit(false);
+export default { contain, cover };


### PR DESCRIPTION
Defaults are unnecessary because it’s a private function.
Exported functions should be constants.
Used object shorthand.

I found your module by chance and deprecated [my duplicate](https://github.com/bfred-it/intrinsic-scale), yours is nicer and even tested!
